### PR TITLE
Add support for ARCH and OS parameters for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,11 @@ RUN go mod download
 COPY main.go main.go
 COPY pkg/ pkg/
 
+ARG GOARCH
+ARG GOOS
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o webhook main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o webhook main.go
 
 # Use distroless as minimal base image to package the webhook binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= webhook:latest
+OS ?= linux
+ARCH ?= amd64
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -46,7 +48,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	docker build --build-arg GOOS="$(OS)" --build-arg GOARCH="$(ARCH)" . -t ${IMG}
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
Adding support for ARCH and OS parameters for docker build. For example, to build for darwin/arm64 OS, specify `OS=darwin ARCH=arm64 make docker-build`