### PR TITLE
docs: need to run docker-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ make deploy
 
 #### Build and deploy webhook
 ```console
-make docker-build IMG=DOCKER_IMAGE_TAG
+make docker-build docker-push IMG=DOCKER_IMAGE_TAG
 make deploy IMG=DOCKER_IMAGE_TAG
 ```
 


### PR DESCRIPTION
The makefile target docker-build (only) builds an image, it does not
push the image.  To deploy to a cluster, we must also make the
docker-push target.