### PR TITLE
Use correct project for image push

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,13 +5,13 @@ steps:
   - name: gcr.io/cloud-builders/docker
     args:
       - build
-      - --tag=k8s.gcr.io/multitenancy/externalip-webhook:$_GIT_TAG
-      - --tag=k8s.gcr.io/multitenancy/externalip-webhook:latest
+      - --tag=gcr.io/$PROJECT_ID/externalip-webhook:$_GIT_TAG
+      - --tag=gcr.io/$PROJECT_ID/externalip-webhook:latest
       - .
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
   # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
 images:
-  - 'k8s.gcr.io/multitenancy/externalip-webhook:$_GIT_TAG'
-  - 'k8s.gcr.io/multitenancy/externalip-webhook:latest'
+  - 'gcr.io/$PROJECT_ID/externalip-webhook:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/externalip-webhook:latest'


### PR DESCRIPTION
We cannot push directly to k8s.gcr.io because those images have to be
promoted correctly. We have to put them into the staging area which is
usually defined by `$PROJECT_ID`.

Follow-up of https://github.com/kubernetes-sigs/externalip-webhook/pull/11
/assign @SaranBalaji90