### PR TITLE
upgdate cert-manager.io/v1alpha2 to cert-manager.io/v1

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,8 +1,8 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
+# WARNING: Targets CertManager 1.6 check https://cert-manager.io/docs/installation/upgrading/ for 
 # breaking changes
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +10,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -40,7 +40,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
@@ -48,7 +48,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:


### PR DESCRIPTION
## Motivation

cert-manager [v1.6.0](https://github.com/jetstack/cert-manager/releases/tag/v1.6.0) was recently released.  And this version [removed many alpha/beta API versions](https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/) which had been deprecated for a long time.

## What The PR Change

The PR updates cert-mangager related API versions in the manifests from `cert-manager.io/v1alpha2` to `cert-manager.io/v1`

## Compatibility

`cert-manager.io/v1` was introduced at cert-manager [v1.0.0](https://github.com/jetstack/cert-manager/releases/tag/v1.0.0) released on September, 2020.  Thus, I believe most users can apply the manifests.

## Test

I confirmed the manifests works on kind cluster (kubernetes v1.21) because kubernetes v1.22 includes API removal of `admissionregistration.k8s.io/v1beta1` (#17 can cover this).

See [the gist](https://gist.github.com/everpeace/e9eaabeba45d812e7febecd32396fe98) for detail.

