### PR TITLE
Add a feature to restrict by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ externalip-webhook, is a validating webhook which prevents services from using r
 can specify list of CIDRs allowed to be used as external IP by specifying `allowed-external-ip-cidrs` parameter.
 Webhook will only allow creation of services which doesn't require external IP or whose external IPs are within the range
 specified by the administrator.
+externalip-webhook can also restrict who can specify allowed ranges of external IPs to services by specifying `allowed-usernames` and `allowed-groups` parameters.
 
 This repo is built using [kubebuilder](https://book.kubebuilder.io/).
 
 ## Deploying
 
 To restrict external IP to certain CIDRs, uncomment and update `allowed-external-ip-cidrs` in [webhook.yaml](config/webhook/webhook.yaml).
+
+To restrict users that can specify external IPs to services, uncomment and update `allowed-usernames` and/or `allowed-groups` in [webhook.yaml](config/webhook/webhook.yaml).
+Default values for both parameters are empty and it means any users can specify.
+If either of the parameters is set, specifying external IPs is restricted to the users that match to any of these parameters.
 
 NOTE: If auth-proxy is enabled then update `allowed-external-ip-cidrs` in [metrics_server_auth_proxy.yaml](config/default/metrics_server_auth_proxy_patch.yaml).
 

--- a/config/webhook/webhook.yaml
+++ b/config/webhook/webhook.yaml
@@ -31,6 +31,8 @@ spec:
           # uncomment the following section to update the respective parameters.
           #args:
           #- --allowed-external-ip-cidrs=10.0.0.0/8,11.0.0.0/8
+          #- --allowed-usernames=system:admin,system:serviceaccount:kube-system:default
+          #- --allowed-groups=system:masters,system:authenticated
           #- --webhook-port=9443
           #- --metrics-addr=0.0.0.0:8443
           image: webhook:latest

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kubernetes-security/externalip-webhook
 go 1.13
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/prometheus/client_golang v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/main.go
+++ b/main.go
@@ -45,12 +45,16 @@ func init() {
 
 func main() {
 	var allowedCIDRs []string
+	var allowedUsernames []string
+	var allowedGroups []string
 	var metricsAddr string
 	var webhookPort int
 
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "Webhook port number")
 	flag.StringVar(&metricsAddr, "metrics-addr", "0", "The address the metric endpoint binds to.")
 	flag.StringSliceVar(&allowedCIDRs, "allowed-external-ip-cidrs", []string{}, "List of CIDR ranges allowed as External IPs in the service spec.")
+	flag.StringSliceVar(&allowedUsernames, "allowed-usernames", []string{}, "List of usernames allowed to assign External IPs in the service spec.")
+	flag.StringSliceVar(&allowedGroups, "allowed-groups", []string{}, "List of groups allowed to assign External IPs in the service spec.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -66,7 +70,7 @@ func main() {
 	}
 
 	setupLog.Info("registering webhook...")
-	serviceValidator, err := validator.NewServiceValidator(allowedCIDRs)
+	serviceValidator, err := validator.NewServiceValidator(allowedCIDRs, allowedUsernames, allowedGroups)
 	if err != nil {
 		setupLog.Error(err, "problem registering webhook")
 		os.Exit(1)

--- a/pkg/validator/service_validator_test.go
+++ b/pkg/validator/service_validator_test.go
@@ -1,11 +1,20 @@
 package validator
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func TestNewServiceValidatorInvalidInput(t *testing.T) {
@@ -94,4 +103,157 @@ func TestIsValidUserNoMatch(t *testing.T) {
 	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8"}, []string{"user2"}, []string{"group2"})
 	actualOutput := newServiceValidator.isValidUser(authenticationv1.UserInfo{Username: "user1", Groups: []string{"group1"}})
 	assert.False(t, actualOutput)
+}
+
+var (
+	serviceWithoutExternalIP = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+`
+
+	serviceWithAllowedExternalIP = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+  externalIPs:
+    - 10.0.0.1
+`
+
+	serviceWithDeniedExternalIP = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+  externalIPs:
+    - 80.11.12.10
+`
+)
+
+func newRequest(svcSpec, username string, groups []string) admission.Request {
+	raw, err := yaml.YAMLToJSON([]byte(svcSpec))
+	if err != nil {
+		return admission.Request{}
+	}
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1beta1.AdmissionRequest{
+			UID: "a2d5bf04-75e5-4f30-9ec6-e648611f22a0",
+			UserInfo: authenticationv1.UserInfo{
+				Username: username,
+				Groups:   groups,
+			},
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+			Operation: "CREATE",
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+		},
+	}
+
+	return req
+}
+
+func TestHandle(t *testing.T) {
+	tc := []struct {
+		name             string
+		allowedIPs       []string
+		allowedUsernames []string
+		allowedGroups    []string
+		serviceSpec      string
+		userName         string
+		groups           []string
+		ExpectAllowed    bool
+	}{
+		{
+			name:             "Create service without externalIP by denied user",
+			allowedIPs:       []string{"10.0.0.0/8"},
+			allowedUsernames: []string{"user2"},
+			allowedGroups:    []string{"group2"},
+			serviceSpec:      serviceWithoutExternalIP,
+			userName:         "user1",
+			groups:           []string{},
+			ExpectAllowed:    true,
+		},
+		{
+			name:             "Create service without externalIP by allowed user (by username)",
+			allowedIPs:       []string{"10.0.0.0/8"},
+			allowedUsernames: []string{"user1"},
+			allowedGroups:    []string{"group2"},
+			serviceSpec:      serviceWithoutExternalIP,
+			userName:         "user1",
+			groups:           []string{},
+			ExpectAllowed:    true,
+		},
+		{
+			name:             "Create service with allowed externalIP by denied user",
+			allowedIPs:       []string{"10.0.0.0/8"},
+			allowedUsernames: []string{"user2"},
+			allowedGroups:    []string{"group2"},
+			serviceSpec:      serviceWithAllowedExternalIP,
+			userName:         "user1",
+			groups:           []string{},
+			ExpectAllowed:    false,
+		},
+		{
+			name:             "Create service with allowed externalIP by allowed user (by group)",
+			allowedIPs:       []string{"10.0.0.0/8"},
+			allowedUsernames: []string{"user2"},
+			allowedGroups:    []string{"group1"},
+			serviceSpec:      serviceWithAllowedExternalIP,
+			userName:         "user1",
+			groups:           []string{"group1"},
+			ExpectAllowed:    true,
+		},
+		{
+			name:             "Create service with denied externalIP by denied user",
+			allowedIPs:       []string{"10.0.0.0/8"},
+			allowedUsernames: []string{"user2"},
+			allowedGroups:    []string{"group2"},
+			serviceSpec:      serviceWithDeniedExternalIP,
+			userName:         "user1",
+			groups:           []string{},
+			ExpectAllowed:    false,
+		},
+		{
+			name:             "Create service with denied externalIP by allowed user (by both username and group)",
+			allowedIPs:       []string{"10.0.0.0/8"},
+			allowedUsernames: []string{"user1"},
+			allowedGroups:    []string{"group1"},
+			serviceSpec:      serviceWithDeniedExternalIP,
+			userName:         "user1",
+			groups:           []string{"group1"},
+			ExpectAllowed:    true,
+		},
+	}
+
+	for _, tt := range tc {
+		newServiceValidator, _ := NewServiceValidator(tt.allowedIPs, tt.allowedUsernames, tt.allowedGroups)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		s := scheme.Scheme
+		corev1.AddToScheme(s)
+		decoder, err := admission.NewDecoder(s)
+		assert.NoError(t, err, "fail to create decorder")
+
+		newServiceValidator.InjectDecoder(decoder)
+
+		actualOutput := newServiceValidator.Handle(ctx, newRequest(tt.serviceSpec, tt.userName, tt.groups))
+		assert.Equal(t, tt.ExpectAllowed, actualOutput.Allowed, "%s: expected allowed %v but got %v", tt.name, tt.ExpectAllowed, actualOutput.Allowed)
+	}
 }

--- a/pkg/validator/service_validator_test.go
+++ b/pkg/validator/service_validator_test.go
@@ -8,31 +8,31 @@ import (
 )
 
 func TestNewServiceValidatorInvalidInput(t *testing.T) {
-	newServiceValidator, err := NewServiceValidator([]string{"12.1.1.a"})
+	newServiceValidator, err := NewServiceValidator([]string{"12.1.1.a"}, []string{}, []string{})
 	assert.Errorf(t, err, "unable to parse input cidr 12.1.1.a")
 	assert.Nil(t, newServiceValidator)
 }
 
 func TestNewServiceValidatorHappyCase(t *testing.T) {
-	newServiceValidator, err := NewServiceValidator([]string{"10.0.0.0/8"})
+	newServiceValidator, err := NewServiceValidator([]string{"10.0.0.0/8"}, []string{}, []string{})
 	assert.Nil(t, err)
 	assert.Len(t, newServiceValidator.allowedExternalIPNets, 1)
 }
 
 func TestValidateExternalIPForSingleAllowedIP(t *testing.T) {
-	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8"})
+	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8"}, []string{}, []string{})
 	actualOutput := newServiceValidator.validateExternalIPs([]string{"10.0.0.5"})
 	assert.True(t, actualOutput.Allowed)
 }
 
 func TestValidateExternalIPForMultipleAllowedIPs(t *testing.T) {
-	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8", "11.0.0.0/8"})
+	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8", "11.0.0.0/8"}, []string{}, []string{})
 	actualOutput := newServiceValidator.validateExternalIPs([]string{"11.0.0.5"})
 	assert.True(t, actualOutput.Allowed)
 }
 
 func TestValidateExternalIPForSingleInvalidInput(t *testing.T) {
-	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8"})
+	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8"}, []string{}, []string{})
 	actualOutput := newServiceValidator.validateExternalIPs([]string{"1.2.e.4"})
 	assert.False(t, actualOutput.Allowed)
 	assert.Equal(t, actualOutput.Result.Reason, v1.StatusReason("spec.externalIPs: Invalid value: "+
@@ -40,7 +40,7 @@ func TestValidateExternalIPForSingleInvalidInput(t *testing.T) {
 }
 
 func TestValidateExternalIPForMultipleInvalidInput(t *testing.T) {
-	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8"})
+	newServiceValidator, _ := NewServiceValidator([]string{"10.0.0.0/8"}, []string{}, []string{})
 	actualOutput := newServiceValidator.validateExternalIPs([]string{"10.0.0.5", "11.0.0.1"})
 	assert.False(t, actualOutput.Allowed)
 	assert.Equal(t, actualOutput.Result.Reason, v1.StatusReason("spec.externalIPs: Invalid value: "+


### PR DESCRIPTION
This PR is to add a feature to restrict by using reqested user's username and groups.

This feature will be useful if the ability to assign external IPs is needed by only specific users or service accounts, not by all the users in the cluster. Actually, I have a use case for assigning external IPs from a controller. Users of this controller won't need to assign external IPs directly, instead users just create the controller's CRD. In this use case, only the service account for the controller is required to have the ability to assign external IPs. Therefore, a feature to restrict by user is needed to provide a safer way for this use case. 

To achieve this feature, we can use `UserInfo.Username` field and `UserInfo.Groups` field in request to check if the requested users are allowed users. In this PR, `allowed-usernames` parameter and `allowed-groups` parameter are added. If both parameters are not set, anyone is allowed to assign external IPs, which is the same behavior to the current implementation. If either of the parameters is set, specifying external IPs is restricted to the users that match to any of these parameters.