### PR TITLE
Update registry k8s.gcr.io -> registry.k8s.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= k8s.gcr.io/multitenancy/externalip-webhook:v1.0.0
+IMG ?= registry.k8s.io/multitenancy/externalip-webhook:v1.0.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
As per https://github.com/kubernetes/k8s.io/issues/4738 replace the usage of the deprecated k8s.gcr.io registry
Verified the digests for images in both registries match.